### PR TITLE
Quitar target="_blank" en enlaces internos

### DIFF
--- a/html/tipos-de-animales/perros.html
+++ b/html/tipos-de-animales/perros.html
@@ -97,7 +97,7 @@
                </p>
 
                <div>
-                  <a title="mas informacion" target="_blank" href="pastor-aleman.html">mas
+                  <a title="mas informacion" href="pastor-aleman.html">mas
                      informacion</a>
                </div>
 
@@ -121,7 +121,7 @@
                   Los Dalmatas son comúnmente utilizados como perros de compañía y también se utilizan como perros
                   de rescate, perros guía y perros de trabajo. Tienen una esperanza de vida de alrededor de 10-13 años.
                </p>
-               <div> <a id="hiden_text_link" title="mas informacion" target="_blank" href="dalmata.html">mas
+               <div> <a id="hiden_text_link" title="mas informacion" href="dalmata.html">mas
                      informacion</a>
                </div>
 
@@ -141,7 +141,7 @@
                <p> Necesitan practicar ejercicio moderado porque, en caso contrario, o si se
                   quedan solos, pueden adoptar comportamientos destructivos.</p>
 
-               <div> <a title="mas informacion" target="_blank" href="san-bernardo.html">mas
+               <div> <a title="mas informacion" href="san-bernardo.html">mas
                      informacion</a>
                </div>
             </div>


### PR DESCRIPTION
Referente a este issue: #1 

Este PR  elimina los `"target="_blank"`de la página perros.html que apuntan a una URL interna.

De esta forma no se abre una nueva pestaña en le navegador.

Se dejan los que si apuntan a una página externa.

Si te parece bien puede hacer un `merge` y luego bajarte los cambios con el comando:

```bash
git pull origin main
```

Si no lo ves adecuado, puede cerrar este PR.